### PR TITLE
Show rounded volume value in notification

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -124,8 +124,8 @@ sink_info_callback(pa_context* c, const pa_sink_info* i, int eol, void* userdata
         } else {
             f_volume = (float)pa_cvolume_avg(&(i->volume)) / (float)PA_VOLUME_NORM;
             f_volume *= 100.0f;
-            g_sprintf(summery, "Volume");
             volume = (int)ceil(f_volume);
+            g_sprintf(summery, "Volume (%d%%)", volume);
         }
 
         if (context->volume != volume) {


### PR DESCRIPTION
This PR add current volume value in notification. This is especially helpful for values over 100%, since in notifications (at least `dunst`) bar won't go over 100.

![image](https://github.com/ikrivosheev/pa-notify/assets/10746427/b2797095-907f-4b73-8322-4ebf0f79603f)
